### PR TITLE
Add global header logo enable

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -802,6 +802,12 @@
         }
     }
 
+    #header-without-global-logo {
+        @extend #header;
+
+        padding: 0;
+    }
+
     #nav {
         cursor: default;
         background-color: #333;

--- a/exampleSite/data/globalheader.yml
+++ b/exampleSite/data/globalheader.yml
@@ -1,1 +1,3 @@
 title: "Arcana _by HTML5 UP_"
+logo:
+  enable: true

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,11 @@
-<div id="header">
-    <h1><a href="{{ .Site.BaseURL }}" id="logo">
-        {{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{ else }}{{ .Site.Title }}{{ end }}
-    </a></h1>
+{{ $globalLogoEnabled := or (not (isset .Site.Data.globalheader.logo "enable")) .Site.Data.globalheader.logo.enable }}
+
+<div id= {{ cond $globalLogoEnabled "header" "header-without-global-logo" }} >
+    {{ if $globalLogoEnabled }}
+        <h1><a href="{{ .Site.BaseURL }}" id="logo">
+            {{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{ else }}{{ .Site.Title }}{{ end }}
+        </a></h1>
+    {{ end }}
 
     <nav id="nav">
         <ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,12 @@
-{{ $globalLogoEnabled := or (not (isset .Site.Data.globalheader.logo "enable")) .Site.Data.globalheader.logo.enable }}
+{{ $globalLogoEnabled := true }}
 
-<div id= {{ cond $globalLogoEnabled "header" "header-without-global-logo" }} >
+{{ with .Site.Data.globalheader }}
+    {{ with .logo }}
+        {{ $globalLogoEnabled = .enable }}
+    {{ end }}
+{{ end }}
+
+<div id="{{ cond $globalLogoEnabled "header" "header-without-global-logo" }}" >
     {{ if $globalLogoEnabled }}
         <h1><a href="{{ .Site.BaseURL }}" id="logo">
             {{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{ else }}{{ .Site.Title }}{{ end }}


### PR DESCRIPTION
Added an extra entry in `globalheader.yml` to control whether global logo is enabled.
```
logo:
  enable: true
```
Is backwards compatible.  If entry is not present, assumes enable: true