### PR TITLE
Fix items_per_row in highlights partial

### DIFF
--- a/layouts/partials/homepage/blocks/highlights.html
+++ b/layouts/partials/homepage/blocks/highlights.html
@@ -1,7 +1,7 @@
 <section class="wrapper style1">
     <div class="container">
         <div class="row gtr-200">
-            {{- $item_cols := (div 12 (.items_per_row | default 3)) }}
+            {{- $item_cols := (div 12 (.item.items_per_row | default 3)) }}
             {{- range .item.items }}
                 <section class="col-{{ $item_cols }} col-12-narrower">
                     <div class="box highlight">


### PR DESCRIPTION
Out of the box, the `items_per_row` doesn't work.

This fixes it.