### PR TITLE
Make top logo clickable on mobile (issue #17)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -39,7 +39,7 @@
             $(
                 '<div id="titleBar">' +
                     '<a href="#navPanel" class="toggle"></a>' +
-                    '<span class="title">' + $('#logo').html() + '</span>' +
+                    '<span class="title">' + $('#logo-wrapper').html() + '</span>' +
                 '</div>'
             )
                 .appendTo($body);

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -1377,18 +1377,36 @@
                 height: 44px;
                 line-height: 44px;
                 box-shadow: 0 4px 0 0 _palette(accent, bg);
+                text-align: center;
 
                 .title {
-                    display: block;
+                    display: inline-block;
                     position: relative;
                     font-weight: 600;
                     text-align: center;
                     color: _palette(accent, fg);
                     z-index: 1;
-
-                    em {
-                        font-style: normal;
-                        font-weight: 300;
+                    
+                    h1 {
+                        @include breakpoint('<=narrower'){
+                            margin: 0;
+                        }
+                        
+                        a {
+                            border-bottom: none;
+                            
+                            em {
+                                font-style: normal;
+                                font-weight: 300;
+                            }
+                            
+                            img {
+                                position: relative;
+                                height: 44px;
+                                padding-bottom: 4px;
+                                vertical-align: middle;
+                            }
+                        } 
                     }
                 }
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,12 +2,12 @@
     {{ if .Site.IsMultiLingual }}
         {{- partial "languages.html" . }}
     {{- end -}}
-    <h1><a href="{{ .Site.BaseURL }}" id="logo">
+    <div id="logo-wrapper"><h1><a href="{{ .Site.BaseURL }}" id="logo">
         {{- if .Site.Data.globalheader.image }}
             <img src="{{ .Site.Data.globalheader.image | relURL }}" alt="{{ .Site.Data.globalheader.image_alt }}" />
         {{- end }}
         {{ with .Site.Data.globalheader.title }}{{ . | markdownify }}{{ else }}{{ .Site.Title }}{{ end }}
-    </a></h1>
+    </a></h1></div>
 
     <nav id="nav">
         <ul>


### PR DESCRIPTION
A fix/improvement from issue #17, as I wanted to implement that on my website too.  I changed the js form getting the inner HTML from a id=logo to a new div id=logo-wrapper that contains the entire h1. Then, I made some changes in the css to display everything correctly.

This also fixes how the logo is displayed on mobile, as before it didn't scale with the navbar:
|Before|After|
|-|-|
|![Before](https://github.com/half-duplex/hugo-arcana/assets/151932430/0f3a16ab-a880-4925-9209-d9318d2867a9)|![After](https://github.com/half-duplex/hugo-arcana/assets/151932430/5547bc50-d2ef-4bfe-a1a4-8aebc6cda855)|

Note: In the screenshot the navbar looks taller than it should because in my website I made it bigger on my custom.scss, but in the theme it's still the same size as before.