### PR TITLE
Update baseof.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,7 +17,7 @@
                         {{- with .Params.sidebar_left }}
                             <div class="col-{{ cond (eq $sidebar_count 1) 4 3 }} col-12-narrower">
                                 <div id="sidebar">
-                                    {{- partial (printf "sidebar/%s.html" .) . }}
+                                    {{- partial (printf "sidebar/%s.html" .) $ }}
                                 </div>
                             </div>
                         {{- end }}
@@ -35,7 +35,7 @@
                         {{- with .Params.sidebar_right }}
                             <div class="col-{{ cond (eq $sidebar_count 1) 4 3 }} col-12-narrower">
                                 <div id="sidebar">
-                                    {{- partial (printf "sidebar/%s.html" .) . }}
+                                    {{- partial (printf "sidebar/%s.html" .) $ }}
                                 </div>
                             </div>
                         {{- end }}


### PR DESCRIPTION
Made a small change (replaced '.' with '$') to allow the full page context to be passed to a custom sidebar partial from the following line:

{{- partial (printf "sidebar/%s.html" .) $ }} 

Previously, only a string was passed to the sidebar partial. The change I'm proposing will allow coders to create a sidebar partial that will list all the tags used in all blog posts. This wouldn't be possible if only a string was passed to the sidebar partial.