### PR TITLE
Avoiding href to empty hash.

### DIFF
--- a/layouts/partials/languages.html
+++ b/layouts/partials/languages.html
@@ -1,5 +1,5 @@
 <div class="dropdown" id="multilingual">
-    <a class="dropbtn language link depth-0" href="#" title="{{ T "language_select" }}" id="languageDropdown" role="button" data-toggle="dropdown" aria-expanded="false">
+    <a class="dropbtn language link depth-0" href="javascript:void(0)" title="{{ T "language_select" }}" id="languageDropdown" role="button" data-toggle="dropdown" aria-expanded="false">
     <i class="fas fa-fw fa-globe"></i>
     <span class="d-lg-none">{{.Site.Language.Lang}}</span>
     </a>


### PR DESCRIPTION
Using an empty hash value as a placeholder for the target of a hyperreference is duprecated: https://stackoverflow.com/questions/5820027/href-with-is-it-bad-practice?utm_source=chatgpt.com

The theme currently does this for the language dropdown. This PR changes it to javascript:void(0).