### PR TITLE
Adding hreflang links to header.

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -4,6 +4,14 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
+{{- if .IsTranslated -}}
+    {{- range $index, $trans := .AllTranslations }}
+        {{- if eq $index 0 }}
+<link href="{{ $trans.Permalink }}" rel="alternate" hreflang="x-default">
+        {{- end }}
+<link href="{{ $trans.Permalink }}" rel="alternate" hreflang="{{ $trans.Language }}">
+    {{- end }}
+{{- end }}
 {{- partial "analytics/google-tag-manager/head.html" . -}}
 {{- partial "head/custom.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}


### PR DESCRIPTION
This generates hreflang links into the header, treating the first language as the default. Reportedly this makes search engines happier. :)

Credit where credit is due: This code is basically copied from the relearn theme:
https://github.com/McShelby/hugo-theme-relearn/blob/main/layouts/_default/baseof.html